### PR TITLE
zfcampus/zf-console tag ~1.0-dev does not exist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "herrera-io/phar-update": "~1.0",
         "zendframework/zend-console": "~2.0",
         "zendframework/zend-filter": "~2.0",
-        "zfcampus/zf-console": "~1.0-dev"
+        "zfcampus/zf-console": "dev-master"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Installation request for zfcampus/zf-deploy dev-master -> satisfiable by zfcampus/zf-deploy[dev-master].
- zfcampus/zf-deploy dev-master requires zfcampus/zf-console ~1.0-dev -> no matching package found

Please either change this dependency or tag zf-console
