### PR TITLE
Fix issue with ZPK creation when --zpkdata is not passed

### DIFF
--- a/src/Deploy.php
+++ b/src/Deploy.php
@@ -275,6 +275,11 @@ class Deploy
      */
     protected function validateZpkDataDir($dir)
     {
+        // No ZPK data dir passed, nothing to do
+        if (empty($dir)) {
+            return true;
+        }
+
         // Does the directory exist? (if not, error!)
         if (! file_exists($dir) || ! is_dir($dir)) {
             return $this->reportError(sprintf('Error: The specified ZPK data directory "%s" does not exist', $dir));


### PR DESCRIPTION
Currently, if you do not pass the `--zpkdata` option when creating a ZPK, the script fails, indicating it does not have a directory to sync. This patch fixes that situation.
