### PR TITLE
Remove `include` of application configuration

### DIFF
--- a/bin/zfdeploy.php
+++ b/bin/zfdeploy.php
@@ -29,6 +29,7 @@ switch (true) {
 
 define('VERSION', '0.3.0-dev');
 
+$routes      = include __DIR__ . '/../config/routes.php';
 $dispatcher  = new Dispatcher();
 $dispatcher->map('self-update', new SelfUpdate(VERSION));
 $dispatcher->map('build', 'ZF\Deploy\Deploy');
@@ -36,7 +37,7 @@ $dispatcher->map('build', 'ZF\Deploy\Deploy');
 $application = new Application(
     'ZFDeploy',
     VERSION,
-    include __DIR__ . '/../config/routes.php',
+    $routes,
     Console::getInstance(),
     $dispatcher
 );

--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,8 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
     ],
     "hash": "f4d547a5ad2b4c49e142024bf3e05e54",
     "packages": [
@@ -485,12 +486,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/fabpot/PHP-CS-Fixer.git",
-                "reference": "ef26ea9a069068b2687bc830c55e12fdde693541"
+                "reference": "5d3097ad43eadd938c64d655a7e7456024b99ec7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fabpot/PHP-CS-Fixer/zipball/ef26ea9a069068b2687bc830c55e12fdde693541",
-                "reference": "ef26ea9a069068b2687bc830c55e12fdde693541",
+                "url": "https://api.github.com/repos/fabpot/PHP-CS-Fixer/zipball/5d3097ad43eadd938c64d655a7e7456024b99ec7",
+                "reference": "5d3097ad43eadd938c64d655a7e7456024b99ec7",
                 "shasum": ""
             },
             "require": {
@@ -506,7 +507,7 @@
             "type": "application",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.4.x-dev"
+                    "dev-master": "0.5.x-dev"
                 }
             },
             "autoload": {
@@ -527,7 +528,7 @@
                 }
             ],
             "description": "A script to automatically fix Symfony Coding Standard",
-            "time": "2014-04-30 07:13:38"
+            "time": "2014-07-13 11:14:10"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1150,7 +1151,9 @@
             "time": "2014-05-16 14:25:18"
         }
     ],
-    "aliases": [],
+    "aliases": [
+
+    ],
     "minimum-stability": "stable",
     "stability-flags": {
         "fabpot/php-cs-fixer": 20
@@ -1158,5 +1161,7 @@
     "platform": {
         "php": ">=5.3.23"
     },
-    "platform-dev": []
+    "platform-dev": [
+
+    ]
 }


### PR DESCRIPTION
Per #24, `include` can be problematic on applications that use ENV variables
or constants inside their `application.config.php`. This patch removes the
`include` in favor of doing static analysis via regexp; it's far from perfect, 
but will work in the majority of use cases.

`include` is still required, however, if you want to selectively enable
modules.
