### PR TITLE
Cannot validate deployment.xml if zfdeploy.phar is in a folder with spaces

### DIFF
--- a/src/Deploy.php
+++ b/src/Deploy.php
@@ -159,13 +159,19 @@ class Deploy
             return $this->reportError(sprintf('Error: The XML schema file "%s" does not exist.', $schema));
         }
 
+        // Copy schema to temp file; fixes portability problem with Windows
+        $tmpSchema = tempnam(sys_get_temp_dir(), 'zfd');
+        copy($schema, $tmpSchema);
+
         // Validate the deployment XML file
         $dom = new DOMDocument();
         $dom->loadXML(file_get_contents($file));
-        if (! $dom->schemaValidate($schema)) {
+        if (! $dom->schemaValidate($tmpSchema)) {
+            unlink($tmpSchema);
             return $this->reportError(sprintf('The XML file "%s" does not validate against the schema "%s".', $file, $schema));
         }
 
+        unlink($tmpSchema);
         return true;
     }
 


### PR DESCRIPTION
If I put zfdeploy.phar in a folder, which name contains spaces, and execute it like this:

`$ /tmp/folder\ with\ space/zfdeploy.phar build xxx.zpk`

then the execution fails with the following output:

```
Creating package "xxx.zpk"...
PHP Warning:  DOMDocument::schemaValidate(): I/O warning : failed to load external entity "phar:///tmp/folder%20with%20space/zfdeploy.phar/src/../config/zpk/schema.xsd" in phar:///tmp/folder with space/zfdeploy.phar/src/Deploy.php on line 165
PHP Warning:  DOMDocument::schemaValidate(): Failed to locate the main schema resource at 'phar:///tmp/folder with space/zfdeploy.phar/src/../config/zpk/schema.xsd'. in phar:///tmp/folder with space/zfdeploy.phar/src/Deploy.php on line 165
PHP Warning:  DOMDocument::schemaValidate(): Invalid Schema in phar:///tmp/folder with space/zfdeploy.phar/src/Deploy.php on line 165
The XML file "/tmp/ZFDeploy_53a1d1c004a96/deployment.xml" does not validate against the schema "phar:///tmp/folder with space/zfdeploy.phar/src/../config/zpk/schema.xsd".
```
