### PR TITLE
Remove check

### DIFF
--- a/src/Deploy.php
+++ b/src/Deploy.php
@@ -240,11 +240,6 @@ class Deploy
             return $this->reportError(sprintf('Error: the folder "%s" does not contain a standard ZF2 application', $target));
         }
 
-        $appConfig = file_get_contents($appConfigPath);
-        if (! preg_match('/\'modules\'\s*=>\s*array\s*\(/s', $appConfig)) {
-            return $this->reportError(sprintf('Error: the folder "%s" does not contain a standard ZF2 application', $target));
-        }
-
         // Set $this->appConfigPath when done
         $opts->appConfigPath = $appConfigPath;
 


### PR DESCRIPTION
Hi,

I'm not sure to understand this check. It prevents us to use ZfDeploy when using PHP 5.4 array notation. Maybe the better solution would be to rewrite the regex to take into account PHP 5.4 array.