### PR TITLE
Directory separator issue with ZIP package created under Windows

### DIFF
--- a/src/Deploy.php
+++ b/src/Deploy.php
@@ -768,7 +768,8 @@ class Deploy
             case 'zip':
             case 'zpk':
                 foreach ($files as $name => $file) {
-                    $packager->addFile($file, substr($file, $dirPos));
+                    $normalizedFile = str_replace('\\', '/', $file);
+                    $packager->addFile($normalizedFile, substr($normalizedFile, $dirPos));
                 }
                 break;
             case 'tar':


### PR DESCRIPTION
There's a major issue with zip packages created under Windows system.
Paths to files inside the archive are using backslash \ as directory separator.

Unpacking such archive under Linux can lead to archive's tree of files being flattened and extracted to current linux directory without preserving the directory tree.

Consider this directory tree inside example zip package:

```
example_directory
|___inside_file1.txt
|___inside_file2.txt
```

Extraction to /var/www ends up in having 2 files without any directories (notice the backslash)
**/var/www/**example_directory\inside_file1.txt
**/var/www/**example_directory\inside_file2.txt

Instead of a directory containing 2 files (notice no backslash)
**/var/www/example_directory**/inside_file1.txt
**/var/www/example_directory**/inside_file2.txt

I'm using the ZipArchive library to extract the archive. To solve this, when adding file to the archive, the path needs to have backslash symbols replaced with slashes. This will work under Linux and continue to work under Windows as well (I tested this behavior).

The code of [Deploy.php](https://github.com/zfcampus/zf-deploy/blob/master/src/Deploy.php#L765):

```php
        switch ($format) {
            case 'zip':
            case 'zpk':
                foreach ($files as $name => $file) {
                    $packager->addFile($file, substr($file, $dirPos));
                }
                break;
            case 'tar':
            case 'tar.gz':
            case 'tgz':
                $packager->buildFromIterator($files, $dir);
                break;
        }
```

should be written as follows:

```php
        switch ($format) {
            case 'zip':
                foreach ($files as $name => $file) {
                    $escapedFile = str_replace('\\', '/', $file);
                    $escapedPath = substr($escapedFile, $dirPos);

                    $packager->addFile($escapedFile , $escapedPath);
                }
                break;
            case 'zpk':
                foreach ($files as $name => $file) {
                    $packager->addFile($file, substr($file, $dirPos));
                }
                break;
            case 'tar':
            case 'tar.gz':
            case 'tgz':
                $packager->buildFromIterator($files, $dir);
                break;
        }
```