### PR TITLE
Check for routing configuration based on vendor binary location

### DIFF
--- a/bin/zfdeploy.php
+++ b/bin/zfdeploy.php
@@ -28,7 +28,23 @@ switch (true) {
 
 define('VERSION', '1.0.3-dev');
 
-$routes      = include __DIR__ . '/../config/routes.php';
+switch (true) {
+    case (file_exists(__DIR__ . '/../config/routes.php')):
+        // Installed standalone
+        $routes = include __DIR__ . '/../config/routes.php';
+        break;
+    case (file_exists(__DIR__ . '/../zfcampus/zf-deploy/config/routes.php')):
+        // Running as vendor binary
+        $routes = include __DIR__ . '/../zfcampus/zf-deploy/config/routes.php';
+        break;
+    default:
+        throw new RuntimeException(
+            'Unable to locate zf-deploy routing configuration; please check that they are available '
+            . 'in one of the following locations, relative to the zfdeploy.php file you are '
+            . 'executing: ../config/routes.php, ../zfcampus/zf-deploy/config/routes.php'
+        );
+}
+
 $application = new Application(
     'ZFDeploy',
     VERSION,


### PR DESCRIPTION
The location of the routing configuration may be relative to the standalone script, or relative to the vendor binary in cases where symlinks do not operate using POSIX rules.

Fixes #30